### PR TITLE
Refactor/UI structure

### DIFF
--- a/app/src/main/java/com/example/nubo/MainActivity.kt
+++ b/app/src/main/java/com/example/nubo/MainActivity.kt
@@ -3,11 +3,41 @@ package com.example.nubo
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -21,6 +51,11 @@ import com.example.nubo.ui.screen.profile.ProfileScreen
 import com.example.nubo.ui.component.BottomNavBar
 import com.example.nubo.ui.screen.card.ShortformListScreen
 import com.example.nubo.ui.screen.myBoard.BoardDetailScreen
+import com.example.nubo.ui.theme.AppFonts
+import com.example.nubo.ui.theme.AppTextStyles
+import com.example.nubo.ui.theme.Grey20
+import com.example.nubo.ui.theme.Grey200
+import com.example.nubo.ui.theme.Grey700
 import com.example.nubo.ui.theme.NuboAppTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -36,6 +71,7 @@ class MainActivity : AppCompatActivity() {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen() {
     val navController = rememberNavController()
@@ -45,63 +81,116 @@ fun MainScreen() {
     // 상세 화면에서는 BottomNavBar 숨기기
     val showBottomBar = currentRoute in listOf("home", "myboard", "add", "learn", "profile")
 
+    // 콘텐츠 추가 전역 시트 상태
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var sheetVisible by remember { mutableStateOf(false) }
+
+
     Scaffold(
         bottomBar = {
             if (showBottomBar) {
                 BottomNavBar(
                     selectedIndex = getSelectedIndex(currentRoute),
                     onItemSelected = { index ->
-                        val route = when (index) {
-                            0 -> "home"
-                            1 -> "myboard"
-                            2 -> "add"
-                            3 -> "learn"
-                            4 -> "profile"
-                            else -> "home"
-                        }
-                        navController.navigate(route) {
-                            popUpTo("home") { inclusive = false }
-                            launchSingleTop = true
+                        when (index) {
+                            0 -> navController.navigate("home") { popUpTo("home"); launchSingleTop = true }
+                            1 -> navController.navigate("myboard") { popUpTo("home"); launchSingleTop = true }
+                            2 -> sheetVisible = true // + 버튼 누르면 시트 열기
+                            3 -> navController.navigate("learn") { popUpTo("home"); launchSingleTop = true }
+                            4 -> navController.navigate("profile") { popUpTo("home"); launchSingleTop = true }
                         }
                     }
                 )
             }
         }
     ) { innerPadding ->
-        NavHost(
-            navController = navController,
-            startDestination = "home",
-            modifier = Modifier.padding(innerPadding)
-        ) {
-            composable("home") {
-                HomeScreen(onMoreClick = { navController.navigate("learn") })
+        Box(Modifier.padding(innerPadding)) {
+            NavHost(
+                navController = navController,
+                startDestination = "home",
+                modifier = Modifier.fillMaxSize()
+            ) {
+                composable("home") { HomeScreen(onMoreClick = { navController.navigate("learn") }) }
+                composable("myboard") { MyBoardScreen(navController) }
+                composable("learn") { LearnScreen() }
+                composable("profile") { ProfileScreen() }
+                composable(
+                    "board_detail/{boardId}/{boardTitle}"
+                ) { backStackEntry ->
+                    val boardId = backStackEntry.arguments?.getString("boardId") ?: ""
+                    val boardTitle = backStackEntry.arguments?.getString("boardTitle") ?: "로딩 중..."
+                    BoardDetailScreen(boardId = boardId, boardTitle = boardTitle, navController = navController)
+                }
             }
-            composable("myboard") {
-                MyBoardScreen(navController) // 👈 NavController 전달
-            }
-            composable("add") {
-                AddScreen()
-            }
-            composable("learn") {
-                LearnScreen()
-            }
-            composable("profile") {
-                ProfileScreen()
-            }
+        }
+    }
 
-            // 나의 보드 상세 화면
-            composable(
-                "board_detail/{boardId}/{boardTitle}"
-            ) { backStackEntry ->
-                val boardId = backStackEntry.arguments?.getString("boardId") ?: ""
-                val boardTitle = backStackEntry.arguments?.getString("boardTitle") ?: "로딩 중..."
-                BoardDetailScreen(
-                    boardId = boardId,
-                    boardTitle = boardTitle,
-                    navController = navController
+    // 전역 모달 바텀 시트
+    if (sheetVisible) {
+        ModalBottomSheet(
+            onDismissRequest = { sheetVisible = false },
+            sheetState = sheetState,
+            dragHandle = { BottomSheetDefaults.DragHandle() },
+            containerColor = Color.White,
+            shape = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 15.dp, end = 15.dp, top = 0.dp, bottom = 15.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("추가 생성하기", style = AppTextStyles.b2_semibold_16)
+
+                Spacer(Modifier.height(20.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(40.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                ) {
+                    SheetOptionButton(
+                        icon = Icons.Outlined.Image,
+                        text = "영상",
+                        onClick = {}
+                    )
+                    SheetOptionButton(
+                        icon = Icons.Outlined.Folder,
+                        text = "보드",
+                        onClick = {  }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SheetOptionButton(
+    icon: ImageVector,
+    text: String,
+    onClick: () -> Unit
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Surface(
+            onClick = onClick,
+            shape = RoundedCornerShape(12.dp),
+            color = Grey20,
+            tonalElevation = 1.dp,
+            modifier = Modifier.size(64.dp)
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = Grey700
                 )
             }
         }
+        Spacer(Modifier.height(6.dp))
+        Text(text, style = AppTextStyles.b3_medium_14)
     }
 }
 

--- a/app/src/main/java/com/example/nubo/MainActivity.kt
+++ b/app/src/main/java/com/example/nubo/MainActivity.kt
@@ -49,6 +49,8 @@ import com.example.nubo.ui.screen.learn.LearnScreen
 import com.example.nubo.ui.screen.myBoard.MyBoardScreen
 import com.example.nubo.ui.screen.profile.ProfileScreen
 import com.example.nubo.ui.component.BottomNavBar
+import com.example.nubo.ui.component.sheet.BottomSheetHost
+import com.example.nubo.ui.component.sheet.SheetRoute
 import com.example.nubo.ui.screen.card.ShortformListScreen
 import com.example.nubo.ui.screen.myBoard.BoardDetailScreen
 import com.example.nubo.ui.theme.AppFonts
@@ -80,10 +82,7 @@ fun MainScreen() {
 
     // 상세 화면에서는 BottomNavBar 숨기기
     val showBottomBar = currentRoute in listOf("home", "myboard", "add", "learn", "profile")
-
-    // 콘텐츠 추가 전역 시트 상태
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    var sheetVisible by remember { mutableStateOf(false) }
+    var sheetRoute by remember { mutableStateOf<SheetRoute?>(null) }
 
 
     Scaffold(
@@ -95,7 +94,7 @@ fun MainScreen() {
                         when (index) {
                             0 -> navController.navigate("home") { popUpTo("home"); launchSingleTop = true }
                             1 -> navController.navigate("myboard") { popUpTo("home"); launchSingleTop = true }
-                            2 -> sheetVisible = true // + 버튼 누르면 시트 열기
+                            2 -> sheetRoute = SheetRoute.AddMenu
                             3 -> navController.navigate("learn") { popUpTo("home"); launchSingleTop = true }
                             4 -> navController.navigate("profile") { popUpTo("home"); launchSingleTop = true }
                         }
@@ -125,74 +124,23 @@ fun MainScreen() {
         }
     }
 
-    // 전역 모달 바텀 시트
-    if (sheetVisible) {
-        ModalBottomSheet(
-            onDismissRequest = { sheetVisible = false },
-            sheetState = sheetState,
-            dragHandle = { BottomSheetDefaults.DragHandle() },
-            containerColor = Color.White,
-            shape = RoundedCornerShape(topStart = 15.dp, topEnd = 15.dp)
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 15.dp, end = 15.dp, top = 0.dp, bottom = 15.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text("추가 생성하기", style = AppTextStyles.b2_semibold_16)
-
-                Spacer(Modifier.height(20.dp))
-
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(40.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                ) {
-                    SheetOptionButton(
-                        icon = Icons.Outlined.Image,
-                        text = "영상",
-                        onClick = {}
-                    )
-                    SheetOptionButton(
-                        icon = Icons.Outlined.Folder,
-                        text = "보드",
-                        onClick = {  }
-                    )
-                }
-            }
+    BottomSheetHost(
+        route = sheetRoute,
+        onDismiss = { sheetRoute = null },
+        onGoCreateBoard = { sheetRoute = SheetRoute.CreateBoard },
+        onGoInvite = { sheetRoute = SheetRoute.Invite },
+        onCreateBoard = { name, isShared ->
+            // TODO: call ViewModel to create board
+            sheetRoute = null
+            // Optional: navigate to new board detail
+            // navController.navigate("board_detail/$newId/${Uri.encode(name)}")
+        },
+        onInvite = { email ->
+            // TODO: invite logic via ViewModel
         }
-    }
+    )
 }
 
-@Composable
-fun SheetOptionButton(
-    icon: ImageVector,
-    text: String,
-    onClick: () -> Unit
-) {
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Surface(
-            onClick = onClick,
-            shape = RoundedCornerShape(12.dp),
-            color = Grey20,
-            tonalElevation = 1.dp,
-            modifier = Modifier.size(64.dp)
-        ) {
-            Box(contentAlignment = Alignment.Center) {
-                Icon(
-                    icon,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = Grey700
-                )
-            }
-        }
-        Spacer(Modifier.height(6.dp))
-        Text(text, style = AppTextStyles.b3_medium_14)
-    }
-}
 
 fun getSelectedIndex(route: String?): Int {
     return when (route) {

--- a/app/src/main/java/com/example/nubo/data/network/NetworkModule.kt
+++ b/app/src/main/java/com/example/nubo/data/network/NetworkModule.kt
@@ -31,7 +31,7 @@ object NetworkModule {
     @Singleton
     fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
-            .baseUrl("https://8c4f977f7e6c.ngrok-free.app")
+            .baseUrl("https://cb22b9d9870b.ngrok-free.app")
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()

--- a/app/src/main/java/com/example/nubo/data/network/NetworkModule.kt
+++ b/app/src/main/java/com/example/nubo/data/network/NetworkModule.kt
@@ -31,7 +31,7 @@ object NetworkModule {
     @Singleton
     fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
-            .baseUrl("https://b08f-2406-5900-1038-741b-c576-33f6-c307-2665.ngrok-free.app")
+            .baseUrl("https://8c4f977f7e6c.ngrok-free.app")
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()

--- a/app/src/main/java/com/example/nubo/data/network/RetrofitClient.kt
+++ b/app/src/main/java/com/example/nubo/data/network/RetrofitClient.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 
 
 object RetrofitClient {
-    private const val BASE_URL = "https://b08f-2406-5900-1038-741b-c576-33f6-c307-2665.ngrok-free.app"
+    private const val BASE_URL = "https://8c4f977f7e6c.ngrok-free.app"
     private val logging = HttpLoggingInterceptor(PrettyJsonLogger()).apply {
         level = HttpLoggingInterceptor.Level.BODY
     }

--- a/app/src/main/java/com/example/nubo/data/network/RetrofitClient.kt
+++ b/app/src/main/java/com/example/nubo/data/network/RetrofitClient.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 
 
 object RetrofitClient {
-    private const val BASE_URL = "https://8c4f977f7e6c.ngrok-free.app"
+    private const val BASE_URL = "https://cb22b9d9870b.ngrok-free.app"
     private val logging = HttpLoggingInterceptor(PrettyJsonLogger()).apply {
         level = HttpLoggingInterceptor.Level.BODY
     }

--- a/app/src/main/java/com/example/nubo/ui/component/BoardDetailContent.kt
+++ b/app/src/main/java/com/example/nubo/ui/component/BoardDetailContent.kt
@@ -44,9 +44,7 @@ fun BoardDetailContent(
 
 
     LazyColumn(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 12.dp),
+        modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(20.dp),
         contentPadding = PaddingValues(bottom = 20.dp)
     ) {

--- a/app/src/main/java/com/example/nubo/ui/component/DetailCardDialog.kt
+++ b/app/src/main/java/com/example/nubo/ui/component/DetailCardDialog.kt
@@ -43,7 +43,7 @@ fun DetailCardDialog(
         LaunchedEffect(Unit) {
             delay(2000L) //데이터 준비 시간
             isPreparing = false
-            delay(5000L) // 5초 기다림
+            delay(3000L) // 5초 기다림
             flipped = true
         }
     }

--- a/app/src/main/java/com/example/nubo/ui/component/sheet/AddMenuSheet.kt
+++ b/app/src/main/java/com/example/nubo/ui/component/sheet/AddMenuSheet.kt
@@ -1,0 +1,102 @@
+package com.example.nubo.ui.component.sheet
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.example.nubo.ui.theme.AppTextStyles
+import com.example.nubo.ui.theme.Grey20
+import com.example.nubo.ui.theme.Grey500
+
+@Composable
+fun AddMenuSheet(
+    onClose: () -> Unit,
+    onVideoClick: () -> Unit,
+    onBoardClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .background(color = Color.White)
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .imePadding()
+            .padding(start = 10.dp,end=10.dp, top = 0.dp, bottom = 15.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Header: 닫기 버튼 + 타이틀
+        Row(
+            modifier = Modifier.padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "추가 생성하기",
+                style = AppTextStyles.b2_semibold_16
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        // Content: 작은 버튼 2개
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(36.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            SheetOption(
+                icon = Icons.Outlined.Download,
+                text = "영상",
+                onClick = onVideoClick
+            )
+            SheetOption(
+                icon = Icons.Outlined.Folder,
+                text = "보드",
+                onClick = onBoardClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun SheetOption(
+    icon: ImageVector,
+    text: String,
+    onClick: () -> Unit
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Surface(
+            onClick = onClick,
+            shape = RoundedCornerShape(14.dp),
+            color = Grey20,
+            tonalElevation = 1.dp,
+            modifier = Modifier.size(72.dp) // 버튼 크기 고정 (작게)
+        ) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = Grey500
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text,
+            style = AppTextStyles.b3_medium_14
+        )
+    }
+}

--- a/app/src/main/java/com/example/nubo/ui/component/sheet/BottomSheetHost.kt
+++ b/app/src/main/java/com/example/nubo/ui/component/sheet/BottomSheetHost.kt
@@ -1,0 +1,49 @@
+package com.example.nubo.ui.component.sheet
+
+
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BottomSheetHost(
+    route: SheetRoute?,                     // which sheet to show
+    onDismiss: () -> Unit,                  // dismiss handler
+    onGoCreateBoard: () -> Unit,            // AddMenu -> CreateBoard
+    onGoInvite: () -> Unit,                 // CreateBoard -> Invite
+    onCreateBoard: (String, Boolean) -> Unit,// create board action
+    onInvite: (String) -> Unit,             // invite action
+    modifier: Modifier = Modifier
+) {
+    if (route == null) return
+
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = Color.White,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        dragHandle = { BottomSheetDefaults.DragHandle() },
+        modifier = modifier
+    ) {
+        when (route) {
+            SheetRoute.AddMenu -> AddMenuSheet(
+                onClose = onDismiss,
+                onVideoClick = { /* TODO: video */ },
+                onBoardClick = onGoCreateBoard
+            )
+            SheetRoute.CreateBoard -> CreateBoardSheet(
+                onClose = onDismiss,
+                onInviteClick = onGoInvite,
+                onCreate = onCreateBoard
+            )
+            SheetRoute.Invite -> InviteSheet(
+                onClose = onDismiss,
+                onInvite = onInvite
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/nubo/ui/component/sheet/CreateBoardSheet.kt
+++ b/app/src/main/java/com/example/nubo/ui/component/sheet/CreateBoardSheet.kt
@@ -1,0 +1,265 @@
+package com.example.nubo.ui.component.sheet
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.PersonAdd
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.dp
+import com.example.nubo.ui.theme.AppTextStyles
+import com.example.nubo.ui.theme.Grey10
+import com.example.nubo.ui.theme.Grey50
+import com.example.nubo.ui.theme.GreyMain100
+import com.example.nubo.ui.theme.Purple100
+import com.example.nubo.ui.theme.PurpleMain500
+
+@Composable
+fun CreateBoardSheet(
+    onClose: () -> Unit,
+    onInviteClick: () -> Unit,
+    onCreate: (name : String, inShared: Boolean) -> Unit
+){
+    var name by rememberSaveable { mutableStateOf("") }
+    var isShared by rememberSaveable { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .background(color = Color.White)
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .imePadding()
+            .padding(start = 20.dp,end=20.dp, top = 0.dp, bottom = 15.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        //헤더
+        Row(modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically)
+        {
+            Spacer(Modifier.width(70.dp))
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = "보드 만들기",
+                style = AppTextStyles.b2_semibold_16
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Button(
+                shape = RoundedCornerShape(10.dp),
+                onClick = onInviteClick,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = PurpleMain500,
+                    contentColor = Color.White
+                )) {
+                Text(text = "생성", style = AppTextStyles.label_semibold_14)
+            }
+        }
+        Spacer(Modifier.height(22.dp))
+
+        //보드 이름
+        Column(
+            horizontalAlignment = Alignment.Start,
+            modifier = Modifier.padding(horizontal = 15.dp)
+        ) {
+            Text("보드 이름", style = AppTextStyles.b2_medium_16)
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = name,
+                onValueChange = {name = it},
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(10.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = PurpleMain500,
+                    unfocusedBorderColor = Grey50,
+                    focusedContainerColor = Color.White,
+                    unfocusedContainerColor = Grey10,
+                )
+            )
+        }
+
+        Spacer(Modifier.height(22.dp))
+
+        //보드 유형
+        Column(
+            horizontalAlignment = Alignment.Start,
+            modifier = Modifier
+                .fillMaxWidth()                 // ✅ 가로 꽉 채우기
+                .padding(horizontal = 15.dp),
+        ) {
+            Text("보드 유형", style = AppTextStyles.b2_medium_16)
+            Spacer(Modifier.height(8.dp))
+            Row (
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ){
+                SegButton(
+                    text ="개인 보드",
+                    selected = !isShared,
+                    onClick = {isShared = false}
+                )
+
+                SegButton(
+                    text ="공유 보드",
+                    selected = isShared,
+                    onClick = {isShared = true}
+                )
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+
+        AnimatedVisibility(
+            visible = isShared,
+            enter = fadeIn(
+                animationSpec = tween(durationMillis = 300) // fadeIn 속도 0.5초
+            ) + expandVertically(
+                animationSpec = tween(durationMillis = 300) // expand 속도 0.5초
+            ),
+            exit = fadeOut(
+                animationSpec = tween(durationMillis = 300) // fadeOut 속도 0.3초
+            ) + shrinkVertically(
+                animationSpec = tween(durationMillis = 300) // shrink 속도 0.3초
+            )
+        ) {
+            //참여자 초대(공유 보드 클릭 시,)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 15.dp),
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text("참여자 초대(선택)", style = AppTextStyles.b2_medium_16)
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+
+                    Row(
+                        modifier = Modifier.weight(1f),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Surface(
+                            shape = CircleShape,
+                            color = Color.Transparent,
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                            modifier = Modifier.size(40.dp)
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(
+                                    imageVector = Icons.Outlined.Person,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.outline
+                                )
+                            }
+                        }
+                        Spacer(Modifier.width(12.dp))
+                        Text("사용자", style = AppTextStyles.b2_medium_16)
+                    }
+
+                    OutlinedButton(
+                        onClick = onInviteClick,
+                        shape = RoundedCornerShape(10.dp),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
+                        modifier = Modifier.height(36.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.onSurface
+                        ),
+                        border = ButtonDefaults.outlinedButtonBorder.copy(
+                            brush = SolidColor(MaterialTheme.colorScheme.outline)
+                        )
+                    ) {
+                        Text("추가")
+                    }
+                }
+            }
+
+        }
+
+
+
+    }
+}
+
+//보드 유형 선택 버튼 커스텀
+@Composable
+private fun SegButton(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    val primary = PurpleMain500
+    val outline = GreyMain100
+    OutlinedButton(
+        onClick = onClick,
+        shape = RoundedCornerShape(10.dp),
+        colors = ButtonDefaults.outlinedButtonColors(
+            containerColor = if (selected)
+                MaterialTheme.colorScheme.surface // white-like
+            else
+                Grey10,
+            contentColor = if (selected) primary else MaterialTheme.colorScheme.onSurface
+        ),
+        border = if (selected)
+            ButtonDefaults.outlinedButtonBorder.copy(
+                brush = SolidColor(primary),
+                width = 1.5.dp
+            )
+        else
+            ButtonDefaults.outlinedButtonBorder.copy(
+                brush = SolidColor(outline),
+                width = 1.dp
+            ),
+        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 16.dp)
+    ) {
+        Text(
+            text = text,
+            style = AppTextStyles.b3_medium_14
+        )
+    }
+}

--- a/app/src/main/java/com/example/nubo/ui/component/sheet/InviteSheet.kt
+++ b/app/src/main/java/com/example/nubo/ui/component/sheet/InviteSheet.kt
@@ -1,0 +1,86 @@
+package com.example.nubo.ui.component.sheet
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.nubo.ui.theme.AppTextStyles
+import com.example.nubo.ui.theme.Grey10
+import com.example.nubo.ui.theme.Grey50
+import com.example.nubo.ui.theme.PurpleMain500
+
+@Composable
+fun InviteSheet (
+    onClose: () -> Unit,
+    onInvite: (String) -> Unit
+){
+    var email by rememberSaveable { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .background(color = Color.White)
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .imePadding()
+            .padding(start = 20.dp,end=20.dp, top = 0.dp, bottom = 15.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier.padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "참여자 초대",
+                style = AppTextStyles.b2_semibold_16
+            )
+        }
+
+        Spacer(Modifier.height(22.dp))
+
+        //보드 이름
+        Column(
+            horizontalAlignment = Alignment.Start,
+            modifier = Modifier.padding(horizontal = 15.dp)
+        ) {
+            Text("이메일", style = AppTextStyles.b2_medium_16)
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = email,
+                onValueChange = {email = it},
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(10.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = PurpleMain500,
+                    unfocusedBorderColor = Grey50,
+                    focusedContainerColor = Color.White,
+                    unfocusedContainerColor = Grey10,
+                )
+            )
+        }
+
+        Spacer(Modifier.height(22.dp))
+
+
+
+    }
+
+}

--- a/app/src/main/java/com/example/nubo/ui/component/sheet/SheetRoute.kt
+++ b/app/src/main/java/com/example/nubo/ui/component/sheet/SheetRoute.kt
@@ -1,0 +1,8 @@
+package com.example.nubo.ui.component.sheet
+
+// Bottom-sheet routing states
+sealed interface SheetRoute {
+    data object AddMenu : SheetRoute
+    data object CreateBoard : SheetRoute
+    data object Invite : SheetRoute
+}

--- a/app/src/main/java/com/example/nubo/ui/screen/add/AddScreen.kt
+++ b/app/src/main/java/com/example/nubo/ui/screen/add/AddScreen.kt
@@ -1,12 +1,63 @@
 package com.example.nubo.ui.screen.add
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
-
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddScreen(padding: PaddingValues = PaddingValues()) {
     Text("AddScreen", style = MaterialTheme.typography.bodyLarge)
+
+        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        val coroutineScope = rememberCoroutineScope()
+        var isSheetOpen by remember { mutableStateOf(true) } // 진입 시 바로 열기
+
+        if (isSheetOpen) {
+            ModalBottomSheet(
+                sheetState = sheetState,
+                onDismissRequest = { isSheetOpen = false },
+                dragHandle = { BottomSheetDefaults.DragHandle() }
+            ) {
+                // 여기에 영상 / 보드 선택 UI
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text("추가 생성하기", style = MaterialTheme.typography.titleMedium)
+
+                    Spacer(Modifier.height(16.dp))
+                    OutlinedButton(
+                        onClick = { /* 영상 로직 */ }
+                    ) { Text("영상") }
+
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = { /* 보드 로직 */ }
+                    ) { Text("보드") }
+                }
+            }
+        }
+
 }

--- a/app/src/main/java/com/example/nubo/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/nubo/ui/screen/home/HomeScreen.kt
@@ -48,7 +48,7 @@ import com.example.nubo.ui.theme.NuboAppTheme
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.nubo.data.model.CardResponse
 import androidx.compose.material.icons.outlined.ChevronRight
-
+import androidx.compose.runtime.LaunchedEffect
 
 
 @Composable
@@ -59,6 +59,9 @@ fun HomeScreen(
     val homeViewModel: HomeViewModel = hiltViewModel()
     val cardList by homeViewModel.cards.observeAsState(emptyList())
 
+    LaunchedEffect(Unit) {
+        homeViewModel.loadCards() // initial load
+    }
 
 
     LazyColumn(
@@ -130,6 +133,7 @@ fun BoardThumbnailCard(item: BoardThumbnailCardItem) {
 fun RecentBoardSection() {
 
     // 더미 데이터
+    // 리스트 순서대로 인덱스 생성
     val items = listOf(
         BoardThumbnailCardItem("엔터테인먼트",imageResId = R.drawable.thumbnail_entertainment),
         BoardThumbnailCardItem("AI 및 개발", imageResId = R.drawable.thumbnail_it),
@@ -155,14 +159,6 @@ fun RecentBoardSection() {
                 }
             }
         }
-//        LazyRow(
-//            horizontalArrangement = Arrangement.spacedBy(12.dp),
-//            contentPadding = PaddingValues(horizontal = 12.dp)
-//        ) {
-//            items(items) { item ->
-//                BoardThumbnailCard(item)
-//            }
-//        }
     }
 }
 

--- a/app/src/main/java/com/example/nubo/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/nubo/ui/screen/home/HomeViewModel.kt
@@ -35,7 +35,7 @@ class HomeViewModel @Inject constructor(
         loadCards()
     }
 
-    private fun loadCards() {
+    fun loadCards() {
         _isLoading.value = true
 
         authRepository.getAccessToken()?.let { token ->

--- a/app/src/main/java/com/example/nubo/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/nubo/ui/theme/Theme.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 
 @Composable
 fun NuboAppTheme(
@@ -11,6 +12,7 @@ fun NuboAppTheme(
     content: @Composable () -> Unit
 ) {
     val colors = if (useDarkTheme) DarkColorScheme else LightColorScheme
+
 
     MaterialTheme(
         colorScheme = colors,


### PR DESCRIPTION

### 변경 사항
- MainActivity에서는 바텀시트 상태만 관리
- 시트 UI는 `ui/component/sheet` 폴더로 분리
- Add → CreateBoard → Invite 흐름을 `SheetRoute` 기반으로 연결

---
### 폴더 구조 및 설명
<img width="222" height="171" alt="image" src="https://github.com/user-attachments/assets/d11adc47-36e2-4be4-a3ea-90b6991b4aed" />

- `ui/component/sheet/SheetRoute.kt`
  - 모든 바텀시트 라우트 정의 (`AddMenu`, `CreateBoard`, `Invite`)
- `ui/component/sheet/BottomSheetHost.kt`
  - 현재 라우트에 맞는 시트 표시
  - AddMenu → CreateBoard → Invite 플로우 연결
- `ui/component/sheet/AddMenuSheet.kt`
  - 영상/보드 선택 UI
- `ui/component/sheet/CreateBoardSheet.kt`
  - 보드 생성 UI (이름, 유형, 공유 보드일 때만 초대 섹션 표시)
- `ui/component/sheet/InviteSheet.kt`
  - 사용자 초대 UI
