### PR TITLE
Fix/fcm token delete

### DIFF
--- a/app/src/main/java/com/example/nubo/MainActivity.kt
+++ b/app/src/main/java/com/example/nubo/MainActivity.kt
@@ -313,6 +313,7 @@ fun MainScreen(
                 composable("profile") {
                     ProfileRoute(
                         navController = navController,
+                        onBellClick ={navController.navigate("notification")},
                         onBack = { navController.popBackStack() },
                         onMyInfo = { navController.navigate("information") },
                         modifier = Modifier.padding(innerPadding),

--- a/app/src/main/java/com/example/nubo/MainActivity.kt
+++ b/app/src/main/java/com/example/nubo/MainActivity.kt
@@ -179,7 +179,7 @@ fun MainScreen(
 
     val toastHost = rememberAppToastHostState()
     val toastScope = rememberCoroutineScope()
-    AppToastOverlay(hostState = toastHost)
+    AppToastOverlay(hostState = toastHost,extraBottomOffset = 72.dp)
 
     val cardUploadVm: CardUploadViewModel = hiltViewModel()
 
@@ -552,7 +552,7 @@ fun MainScreen(
         // 미시청 목록(학습 탭) 진입 플래그가 있으면 이동함
         if (DeepLinkStore.pendingGoUnread) {
             DeepLinkStore.pendingGoUnread = false
-            navController.navigate("learn") {
+            navController.navigate("myboard") {
                 popUpTo("home") { inclusive = false }
                 launchSingleTop = true
             }

--- a/app/src/main/java/com/example/nubo/data/network/ProfileService.kt
+++ b/app/src/main/java/com/example/nubo/data/network/ProfileService.kt
@@ -5,7 +5,10 @@ import com.example.nubo.data.model.NotificationSetRequest
 import com.example.nubo.data.model.ProfileResponse
 import com.google.android.gms.common.api.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Headers
 import retrofit2.http.PATCH
 
 interface ProfileService {
@@ -24,4 +27,11 @@ interface ProfileService {
     suspend fun updateNotification(
         @Body body: NotificationSetRequest
     ):retrofit2.Response<Unit>
+
+    // 회원 탈퇴 (204 No Content)
+    @Headers("Content-Type: application/json")
+    @DELETE("/api/user/me")
+    suspend fun deleteMe(
+        @Header("Authorization") bearer: String
+    ): retrofit2.Response<Unit>
 }

--- a/app/src/main/java/com/example/nubo/data/repository/BoardRepository.kt
+++ b/app/src/main/java/com/example/nubo/data/repository/BoardRepository.kt
@@ -16,7 +16,7 @@ import retrofit2.HttpException
 import javax.inject.Inject
 
 class BoardRepository @Inject constructor(
-    private val boardService: BoardService
+    private val boardService: BoardService,
 ) {
     // 최근 본 보드 조회
     suspend fun getRecentBoards(token: String): Result<List<RecentBoardResponse>> = runCatching {

--- a/app/src/main/java/com/example/nubo/data/repository/NotificationRepository.kt
+++ b/app/src/main/java/com/example/nubo/data/repository/NotificationRepository.kt
@@ -26,6 +26,7 @@ class NotificationRepository @Inject constructor(
 
     companion object {
         private const val KEY_REGISTERED_TOKEN = "registered_fcm_token"
+        private const val KEY_REGISTERED_AT = "registered_at_epoch"
     }
 
     @Volatile private var lastRegistered: String? = null
@@ -38,25 +39,36 @@ class NotificationRepository @Inject constructor(
         data class Failure(val error: Throwable) : RegisterOutcome()
     }
 
-    suspend fun registerDeviceTokenIfNeeded(fcmToken: String): RegisterOutcome {
+    suspend fun registerDeviceTokenIfNeeded(
+        fcmToken: String,
+        force: Boolean = false,
+        ttlHours: Int = 24
+    ): RegisterOutcome {
         if (fcmToken.isBlank()) {
             android.util.Log.w("FCM_REG", "skip: blank token")
             return RegisterOutcome.SkippedBlank
         }
 
+        val now = System.currentTimeMillis()
         val lastInMem = lastRegistered
         val lastInPrefs = prefs.getString(KEY_REGISTERED_TOKEN, null)
+        val lastAt = prefs.getLong(KEY_REGISTERED_AT, 0L)
+        val expired = (now - lastAt) > ttlHours * 60L * 60L * 1000L
 
-        if (fcmToken == lastInMem || fcmToken == lastInPrefs) {
-            android.util.Log.d("FCM_REG", "skip: already registered (mem=${lastInMem != null}, prefs=${lastInPrefs != null})")
+        // 이미 등록 + TTL 유효 + force 아님 → 스킵
+        if (!force && !expired && (fcmToken == lastInMem || fcmToken == lastInPrefs)) {
+            android.util.Log.d("FCM_REG", "skip: already registered (mem=${lastInMem != null}, prefs=${lastInPrefs != null}), expired=$expired")
             return RegisterOutcome.SkippedAlready
         }
 
-        android.util.Log.d("FCM_REG", "try register (${fcmToken.take(12)}...)")
+        android.util.Log.d("FCM_REG", "try register (force=$force, expired=$expired, ${fcmToken.take(12)}...)")
         return runCatching {
-            api.registerDeviceToken(RegisterDeviceTokenRequest(fcmToken))
+            api.registerDeviceToken(RegisterDeviceTokenRequest(fcmToken)) // 서버 upsert 전제
             lastRegistered = fcmToken
-            prefs.edit { putString(KEY_REGISTERED_TOKEN, fcmToken) }
+            prefs.edit {
+                putString(KEY_REGISTERED_TOKEN, fcmToken)
+                putLong(KEY_REGISTERED_AT, now)
+            }
             android.util.Log.d("FCM_REG", "success 200 (${fcmToken.take(12)}...)")
             RegisterOutcome.Success
         }.getOrElse { e ->
@@ -65,10 +77,40 @@ class NotificationRepository @Inject constructor(
         }
     }
 
+//    suspend fun registerDeviceTokenIfNeeded(fcmToken: String): RegisterOutcome {
+//        if (fcmToken.isBlank()) {
+//            android.util.Log.w("FCM_REG", "skip: blank token")
+//            return RegisterOutcome.SkippedBlank
+//        }
+//
+//        val lastInMem = lastRegistered
+//        val lastInPrefs = prefs.getString(KEY_REGISTERED_TOKEN, null)
+//
+//        if (fcmToken == lastInMem || fcmToken == lastInPrefs) {
+//            android.util.Log.d("FCM_REG", "skip: already registered (mem=${lastInMem != null}, prefs=${lastInPrefs != null})")
+//            return RegisterOutcome.SkippedAlready
+//        }
+//
+//        android.util.Log.d("FCM_REG", "try register (${fcmToken.take(12)}...)")
+//        return runCatching {
+//            api.registerDeviceToken(RegisterDeviceTokenRequest(fcmToken))
+//            lastRegistered = fcmToken
+//            prefs.edit { putString(KEY_REGISTERED_TOKEN, fcmToken) }
+//            android.util.Log.d("FCM_REG", "success 200 (${fcmToken.take(12)}...)")
+//            RegisterOutcome.Success
+//        }.getOrElse { e ->
+//            android.util.Log.w("FCM_REG","fail: ${e.message}")
+//            RegisterOutcome.Failure(e)
+//        }
+//    }
+
     suspend fun deleteDeviceToken(fcmToken: String) {
         runCatching {
             api.deleteDeviceToken(DeleteDeviceTokenRequest(deviceToken = fcmToken))
-            prefs.edit() { remove(KEY_REGISTERED_TOKEN) }
+            prefs.edit() {
+                remove(KEY_REGISTERED_TOKEN)
+                remove(KEY_REGISTERED_AT)
+            }
             lastRegistered = null
         }.onFailure { e ->
             android.util.Log.e("FCM","deleteDeviceToken failed", e)
@@ -121,4 +163,30 @@ class NotificationRepository @Inject constructor(
     suspend fun markAllRead() {
         api.markAllRead()
     }
+
+    // NotificationRepository.kt
+    suspend fun deleteRegisteredTokenIfAny() {
+        val prefs = context.getSharedPreferences("push_prefs", Context.MODE_PRIVATE)
+        val reg = prefs.getString(KEY_REGISTERED_TOKEN, null)
+        val cachedLatest = prefs.getString("latest_fcm_token", null)
+
+        // 1) 서버에 등록됐다고 기억한 토큰이 있으면 우선 삭제
+        if (!reg.isNullOrBlank()) {
+            runCatching { api.deleteDeviceToken(DeleteDeviceTokenRequest(reg)) }
+                .onSuccess {
+                    prefs.edit { remove(KEY_REGISTERED_TOKEN) }
+                    lastRegistered = null
+                    android.util.Log.d("FCM_REG", "deleted registered token (${reg.take(12)}...)")
+                }
+                .onFailure { android.util.Log.w("FCM_REG", "delete registered failed: ${it.message}") }
+        }
+
+        // 2) 캐시 최신 토큰도 다를 수 있으니 한 번 더 시도(중복이면 서버에서 idempotent 처리 가정)
+        if (!cachedLatest.isNullOrBlank() && cachedLatest != reg) {
+            runCatching { api.deleteDeviceToken(DeleteDeviceTokenRequest(cachedLatest)) }
+                .onSuccess { android.util.Log.d("FCM_REG", "deleted cached latest (${cachedLatest.take(12)}...)") }
+                .onFailure { android.util.Log.w("FCM_REG", "delete cached latest failed: ${it.message}") }
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/nubo/data/repository/ProfileRepository.kt
+++ b/app/src/main/java/com/example/nubo/data/repository/ProfileRepository.kt
@@ -9,7 +9,14 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import retrofit2.HttpException
 import javax.inject.Inject
 import androidx.core.content.edit
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import retrofit2.Response
 
+sealed interface AuthEvent {
+    data object LoginRequired : AuthEvent
+}
 
 private const val PREFS_NAME = "notification_prefs"
 private const val KEY_PUSH = "push_enabled"
@@ -17,8 +24,38 @@ private const val KEY_REMIND = "remind_enabled"
 
 class ProfileRepository @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val profileService: ProfileService
+    private val profileService: ProfileService,
+    private val authRepository: AuthRepository,
+    private val notificationRepository: NotificationRepository,
 ) {
+    // ───────── 인증 이벤트 채널(뷰모델이 구독) ─────────
+    private val _authEvents = MutableSharedFlow<AuthEvent>(extraBufferCapacity = 1)
+    val authEvents: SharedFlow<AuthEvent> = _authEvents.asSharedFlow()
+
+    // ───────── 내부 헬퍼: 저장된 토큰 → Bearer 문자열 생성 ─────────
+    private fun bearerOrNull(): String? =
+        authRepository.getAccessToken()?.let { "Bearer $it" }
+
+    // ───────── 내부 헬퍼: Response<T> → Result<T> (+401/403 처리) ─────────
+    private suspend fun <T> asResult(resp: Response<T>): Result<T> {
+        if (resp.isSuccessful) return Result.success(resp.body() as T)
+        if (resp.code() == 401 || resp.code() == 403) {
+            // 토큰 없음/만료 → 로그인 필요 이벤트 발행
+            _authEvents.emit(AuthEvent.LoginRequired)
+            return Result.failure(IllegalStateException("Unauthorized"))
+        }
+        return Result.failure(HttpException(resp))
+    }
+    private suspend fun asResultUnit(resp: Response<Unit>): Result<Unit> {
+        if (resp.isSuccessful) return Result.success(Unit)
+        if (resp.code() == 401 || resp.code() == 403) {
+            _authEvents.emit(AuthEvent.LoginRequired)
+            return Result.failure(IllegalStateException("Unauthorized"))
+        }
+        return Result.failure(HttpException(resp))
+    }
+
+
     // 프로필 확인
     suspend fun fetchProfile(): Result<ProfileResponse> = runCatching {
         profileService.getProfile()
@@ -52,5 +89,26 @@ class ProfileRepository @Inject constructor(
             putBoolean(KEY_PUSH, push)
             putBoolean(KEY_REMIND, remind)
         }
+    }
+
+    suspend fun withdraw(): Result<Unit> {
+        // 1) 현재 기기 FCM 매핑을 먼저 제거(실패해도 계속)
+        runCatching { notificationRepository.deleteRegisteredTokenIfAny() }
+
+        // 2) 토큰이 없으면 로그인 필요 신호
+        val bearer = bearerOrNull() ?: run {
+            _authEvents.emit(AuthEvent.LoginRequired)
+            return Result.failure(IllegalStateException("Missing token"))
+        }
+
+        // 2-1) 실제 탈퇴 API 호출 후 결과 변환(401/403 처리 포함)
+        val result = asResult(profileService.deleteMe(bearer))
+
+        // 3) 성공이면 로컬 인증 데이터 정리
+        if (result.isSuccess) {
+            authRepository.clearAuthData()
+        }
+
+        return result
     }
 }

--- a/app/src/main/java/com/example/nubo/ui/component/toast/ToastMain.kt
+++ b/app/src/main/java/com/example/nubo/ui/component/toast/ToastMain.kt
@@ -528,12 +528,27 @@ fun ToastDemoScreen(
 @Composable
 fun AppToastOverlay(
     hostState: AppToastHostState,
-    extraBottomOffset: Dp = 88.dp,
+    extraBottomOffset: Dp = 72.dp,
 ) {
     // 네비게이션 바 인셋 계산 (한 번만)
     val bottomInset = WindowInsets.navigationBars
         .asPaddingValues()
         .calculateBottomPadding()
+
+    // 토스트 표시 여부를 오버레이 레벨에서 관리
+    var showOverlay by remember { mutableStateOf(false) }
+    // exit 동안만 잠깐 더 유지
+    LaunchedEffect(hostState.current) {
+        if (hostState.current != null) {
+            showOverlay = true
+        } else {
+            // AppToastHost.exit 애니메이션 140ms + 버퍼
+            kotlinx.coroutines.delay(200)
+            showOverlay = false
+        }
+    }
+
+    if (!showOverlay) return  // 완전히 사라지면 Popup 자체를 제거해 터치 통과
 
     Popup(
         alignment = Alignment.BottomCenter,
@@ -541,13 +556,14 @@ fun AppToastOverlay(
             focusable = false,
             dismissOnBackPress = false,
             dismissOnClickOutside = false,
-            excludeFromSystemGesture = false,
+            excludeFromSystemGesture = true,
             usePlatformDefaultWidth = false
         )
     ) {
+        // 하단 바 클릭영역과 겹치지 않도록 충분히 올려둠
         Column(
             modifier = Modifier
-                .padding(bottom = bottomInset + 12.dp)
+                .padding(bottom = bottomInset + extraBottomOffset)
                 .fillMaxWidth(),   // 폭 안정 (크래시 방지)
             horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/app/src/main/java/com/example/nubo/ui/screen/onBoardingLogin/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/example/nubo/ui/screen/onBoardingLogin/OnBoardingViewModel.kt
@@ -36,6 +36,7 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import javax.inject.Inject
+import androidx.core.content.edit
 
 data class UiToast(
     val message: String,
@@ -70,6 +71,8 @@ class OnBoardingViewModel @Inject constructor(
     private suspend fun emitToast(toast: UiToast) {
         _toastEvents.emit(toast)
     }
+
+    private var pendingAccessToken: String? = null
 
     // 알림 권한 요청이 필요한지 상태 관리
     private val _shouldRequestNotificationPermission = MutableStateFlow(false)
@@ -196,6 +199,9 @@ class OnBoardingViewModel @Inject constructor(
     private fun handleTokenExpired() {
         Log.i("Auth", "Token expired, clearing stored data")
         authRepository.clearAuthData()
+        viewModelScope.launch {
+            runCatching { notificationRepository.deleteRegisteredTokenIfAny() }
+        }
         // 커스텀 토스트로 발행 (NEGATIVE)
         toast("로그인이 만료되었습니다. 다시 로그인해주세요.", type = AppToastType.NEGATIVE)
         showLoginButton()
@@ -236,6 +242,10 @@ class OnBoardingViewModel @Inject constructor(
 
 
     private fun sendAuthCodeToServer(authCode: String, onLoginComplete: (Intent) -> Unit) {
+        viewModelScope.launch {
+            runCatching { notificationRepository.deleteRegisteredTokenIfAny() }
+        }
+
         _uiState.value = _uiState.value.copy(isLoading = true)
         val request = LoginRequest(authCode)
 
@@ -248,6 +258,8 @@ class OnBoardingViewModel @Inject constructor(
                             val existingUser = authRepository.getUserInfo()
                             val newUser = loginResponse.user
 
+                            pendingAccessToken = loginResponse.accessToken
+
                             if (existingUser != null && existingUser.id != newUser.id) {
                                 _uiState.value = _uiState.value.copy(
                                     existingUser = existingUser,
@@ -255,6 +267,8 @@ class OnBoardingViewModel @Inject constructor(
                                 )
                             } else {
                                 saveUserAndNavigate(newUser, loginResponse.accessToken, onLoginComplete)
+                                // Clear the held token since it's already persisted
+                                pendingAccessToken = null
                             }
                         }
                     } else {
@@ -271,8 +285,19 @@ class OnBoardingViewModel @Inject constructor(
 
     fun confirmAccountSwitch(onLoginComplete: (Intent) -> Unit) {
         val newUser = _uiState.value.loginResponseUser ?: return
-        val accessToken = authRepository.getAccessToken() ?: return
-        saveUserAndNavigate(newUser, accessToken, onLoginComplete)
+        val accessTokenFromLogin = pendingAccessToken
+        if (accessTokenFromLogin.isNullOrEmpty()) {
+            // Safety fallback: if somehow missing, read from repo (should not usually happen)
+            android.util.Log.w("Auth", "pendingAccessToken is null; falling back to repository token")
+            val fallback = authRepository.getAccessToken() ?: return
+            saveUserAndNavigate(newUser, fallback, onLoginComplete)
+        } else {
+            saveUserAndNavigate(newUser, accessTokenFromLogin, onLoginComplete)
+            // Once persisted, clear the held token
+            pendingAccessToken = null
+        }
+
+        viewModelScope.launch { runCatching { notificationRepository.deleteRegisteredTokenIfAny() } }
     }
 
     @SuppressLint("HardwareIds")
@@ -285,20 +310,23 @@ class OnBoardingViewModel @Inject constructor(
                     android.util.Log.w("FCM_REG", "getToken OK but empty")
                     return@addOnSuccessListener
                 }
-                android.util.Log.d("FCM_REG", "getToken OK (${fcmToken.take(12)}...)")
-                viewModelScope.launch { registerTokenIfNeeded(fcmToken) }
+                android.util.Log.d("FCM_REG", "getToken OK (${fcmToken}...)")
+//                viewModelScope.launch { registerTokenIfNeeded(fcmToken) }
+                prefs.edit() { putString("latest_fcm_token", fcmToken).apply() }
+                viewModelScope.launch { notificationRepository.registerDeviceTokenIfNeeded(fcmToken, force = true) }
+
             }
             .addOnFailureListener { e ->
                 // ⬇ FCM이 바로 토큰 못 줄 때 캐시로 보완
                 val cached = prefs.getString("latest_fcm_token", null)
-                android.util.Log.w("FCM_REG", "getToken FAIL ${e.message}; cached=${cached?.take(12)}...")
+                android.util.Log.w("FCM_REG", "getToken FAIL ${e.message}; cached=${cached}...")
                 if (!cached.isNullOrBlank()) {
-                    viewModelScope.launch { registerTokenIfNeeded(cached) }
+                    viewModelScope.launch { notificationRepository.registerDeviceTokenIfNeeded(cached, force = true) }
                 }
             }
     }
 
-    fun ensurePushTokenRegistered() {
+    fun ensurePushTokenRegistered(force: Boolean = false) {
         FirebaseMessaging.getInstance().isAutoInitEnabled = true
         FirebaseMessaging.getInstance().token
             .addOnSuccessListener { token ->
@@ -306,14 +334,18 @@ class OnBoardingViewModel @Inject constructor(
                     android.util.Log.w("FCM_REG", "ensure: getToken empty")
                 } else {
                     android.util.Log.d("FCM_REG", "ensure: getToken (${token.take(12)}...)")
-                    viewModelScope.launch { registerTokenIfNeeded(token) }
+//                    viewModelScope.launch { registerTokenIfNeeded(token) }
+                    viewModelScope.launch { notificationRepository.registerDeviceTokenIfNeeded(token, force = force) }
+
                 }
             }
             .addOnFailureListener { e ->
                 val cached = prefs.getString("latest_fcm_token", null)
                 android.util.Log.w("FCM_REG", "ensure: getToken FAIL ${e.message}; cached=${cached?.take(12)}...")
                 if (!cached.isNullOrBlank()) {
-                    viewModelScope.launch { registerTokenIfNeeded(cached) }
+//                    viewModelScope.launch { registerTokenIfNeeded(cached) }
+                    viewModelScope.launch { notificationRepository.registerDeviceTokenIfNeeded(cached, force = force) }
+
                 }
             }
     }

--- a/app/src/main/java/com/example/nubo/ui/screen/profile/AuthViewModel.kt
+++ b/app/src/main/java/com/example/nubo/ui/screen/profile/AuthViewModel.kt
@@ -1,22 +1,82 @@
 package com.example.nubo.ui.screen.profile
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.nubo.data.repository.AuthEvent
 import com.example.nubo.data.repository.AuthRepository
+import com.example.nubo.data.repository.NotificationRepository
+import com.example.nubo.data.repository.ProfileRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.collectLatest
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class AuthViewModel @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,      // 로컬 정리 등에 사용
+    private val profileRepository: ProfileRepository
 ) : ViewModel() {
 
-    // 모든 인증 관련 데이터(access, userId, userInfo) 삭제
-    fun logoutClearAll() {
-        authRepository.clearAuthData()
+    // UI에서 사용할 상태
+    private val _isLoading = MutableLiveData(false)
+    val isLoading: LiveData<Boolean> get() = _isLoading
+
+    private val _requireLogin = MutableLiveData<Unit>()
+    val requireLogin: LiveData<Unit> get() = _requireLogin
+
+    private val _withdrawSuccess = MutableLiveData<Unit>()
+    val withdrawSuccess: LiveData<Unit> get() = _withdrawSuccess
+
+    private val _errorMessage = MutableLiveData<String?>()
+    val errorMessage: LiveData<String?> get() = _errorMessage
+
+    init {
+        // 레포가 발행하는 인증 이벤트 구독 → UI로 "로그인 필요" 신호만 전달
+        viewModelScope.launch {
+            profileRepository.authEvents.collectLatest { evt ->
+                when (evt) {
+                    is AuthEvent.LoginRequired -> _requireLogin.postValue(Unit)
+                }
+            }
+        }
     }
 
-    // access/userId만 삭제
-    fun logoutBasic() {
-        authRepository.logout()
+    /**
+     * 로그아웃 오케스트레이션
+     * 1) 서버에 등록된 '현재 기기 FCM 토큰 매핑' 삭제 (best-effort, 실패해도 앱은 계속)
+     * 2) 로컬 인증 정보(Access 토큰, 유저 ID/정보) 삭제
+     * 3) latest_fcm_token 캐시는 유지하여 이후 재로그인 시 재등록 경로로 활용
+     */
+    fun logout() {
+        viewModelScope.launch {
+            // 로컬 인증 정보만 삭제 (FCM 매핑 삭제가 필요하면 ProfileRepository가 아닌 별도 Repo에서 수행)
+            authRepository.clearAuthData()
+        }
+    }
+
+    /**
+     * 회원 탈퇴 오케스트레이션(클라이언트 측 단계)
+     * 1) 현재 기기 FCM 토큰 매핑 삭제 (best-effort)
+     * 2) 서버 탈퇴 API 호출 (콜백 인자로 실제 API를 주입)
+     * 3) 로컬 인증 정보 삭제
+     * 4) 후처리 콜백(onDone) 호출
+     */
+    fun withdraw() {
+        _isLoading.value = true
+        _errorMessage.value = null
+
+        viewModelScope.launch {
+            profileRepository.withdraw()
+                .onSuccess {
+                    _isLoading.value = false
+                    _withdrawSuccess.value = Unit
+                }
+                .onFailure { e ->
+                    _isLoading.value = false
+                    _errorMessage.value = e.message ?: "회원 탈퇴에 실패했어요."
+                }
+        }
     }
 }

--- a/app/src/main/java/com/example/nubo/ui/screen/profile/InformationScreen.kt
+++ b/app/src/main/java/com/example/nubo/ui/screen/profile/InformationScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -77,6 +78,27 @@ fun InformationScreen(
     //로그아웃 뷰모델
     val authViewModel: AuthViewModel = hiltViewModel()
 
+    // 상태 관찰
+    val isLoading by authViewModel.isLoading.observeAsState(initial = false)
+    val requireLogin by authViewModel.requireLogin.observeAsState()
+    val withdrawSuccess by authViewModel.withdrawSuccess.observeAsState()
+    val errorMessage by authViewModel.errorMessage.observeAsState()
+
+    LaunchedEffect(requireLogin) {
+        requireLogin ?: return@LaunchedEffect
+        // 로그인 필요 → 상위 전환 로직 사용(또는 로그인 화면 이동)
+        onLogout()
+    }
+    LaunchedEffect(withdrawSuccess) {
+        withdrawSuccess ?: return@LaunchedEffect
+        // 탈퇴 성공 → 상위 전환(onWithdraw) 실행
+        onWithdraw()
+    }
+    LaunchedEffect(errorMessage) {
+        errorMessage ?: return@LaunchedEffect
+        // TODO: 스낵바/토스트 등 사용자 안내
+    }
+
     Scaffold(
         topBar = {
             TopBar(onBack = {
@@ -116,12 +138,14 @@ fun InformationScreen(
                 name = currentName,
                 email = email,
                 onLogout = {
-                    //  토큰/유저정보 삭제
-                    authViewModel.logoutClearAll()
-                    // 화면 전환은 상위(MainActivity)에서 처리하도록 콜백 호출
+                    // 로그아웃: 서버의 현재 기기 FCM 매핑 삭제 + 로컬 인증정보 삭제
+                    authViewModel.logout()
+                    // 화면 전환 등 후처리는 상위 콜백에서 처리
                     onLogout()
                 },
-                onWithdraw = onWithdraw,
+                onWithdraw = {
+                    authViewModel.withdraw()
+                },
                 onEditName = onEditName
             )
         }

--- a/app/src/main/java/com/example/nubo/ui/screen/profile/NotificationSetScreen.kt
+++ b/app/src/main/java/com/example/nubo/ui/screen/profile/NotificationSetScreen.kt
@@ -10,14 +10,21 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationManagerCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.navigation.NavController
+import com.example.components.toast.AppToastHost
+import com.example.components.toast.AppToastLayout
+import com.example.components.toast.AppToastType
+import com.example.components.toast.rememberAppToastHostState
 import com.example.nubo.R
 import com.example.nubo.ui.theme.AppTextStyles
 import com.example.nubo.ui.theme.Grey1000
@@ -30,6 +37,7 @@ import com.example.nubo.ui.theme.PurpleMain500
 import com.example.nubo.utils.buildAppNotificationSettingsIntent
 import com.example.nubo.utils.rememberNotificationSettingsLauncher
 import kotlinx.coroutines.launch
+import kotlin.math.max
 
 // 알림 설정 화면
 
@@ -80,84 +88,104 @@ fun NotificationSetScreen(
     val scope = rememberCoroutineScope()
     val snackbar = remember { SnackbarHostState() }
 
+    val toastHost = rememberAppToastHostState()
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { ev ->
+            if (ev is ProfileEvent.ShowToast) {
+                val type = when (ev.kind) {
+                    ToastKind.POSITIVE -> AppToastType.POSITIVE
+                    ToastKind.NEGATIVE -> AppToastType.NEGATIVE
+                    ToastKind.NORMAL   -> AppToastType.NORMAL
+                }
+                toastHost.show(
+                    title = AnnotatedString(ev.message),
+                    layout = AppToastLayout.TitleOnly,
+                    type = type,
+                    durationMillis = ev.durationMillis
+                )
+            }
+        }
+    }
+
+
+
     Scaffold(
         topBar = { NotiTopBar(onBack = onBack) },
         snackbarHost = { SnackbarHost(hostState = snackbar) } // ← 실패 시 안내 토스트
     ) { inner ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(inner)
-        ) {
-            SystemNotificationBanner(
-                notificationsEnabled = notificationsEnabled,
-                onClickEnable = {
-                    com.example.nubo.utils.NotificationPermissionHelper.openAppNotificationSettings(context)
-                }
-            )
+        Box(Modifier.fillMaxSize().padding(inner)) {
 
-            Spacer(Modifier.height(3.dp))
-            Divider(color = Grey50)
-            Spacer(Modifier.height(16.dp))
+            Column(modifier = Modifier.fillMaxSize()) {
+                SystemNotificationBanner(
+                    notificationsEnabled = notificationsEnabled,
+                    onClickEnable = {
+                        com.example.nubo.utils.NotificationPermissionHelper.openAppNotificationSettings(context)
+                    }
+                )
 
-            // 전체 알림 섹션
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp, horizontal = 32.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = "전체 알림",
-                        style = AppTextStyles.b1_semibold_18,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                    Spacer(Modifier.width(6.dp))
-                    Text(
-                        text = if (ui.pushEnabled) "허용" else "미허용",
-                        style = AppTextStyles.b1_semibold_18,
-                        color = if (ui.pushEnabled) PurpleMain500 else GreyMain300
-                    )
-                    Spacer(modifier = Modifier.weight(1f))
+                Spacer(Modifier.height(3.dp))
+                Divider(color = Grey50)
+                Spacer(Modifier.height(16.dp))
 
-                    Switch(
-                        checked = ui.pushEnabled,
-                        onCheckedChange = { checked ->
-                            scope.launch {
-                                viewModel.togglePush(checked) { msg ->
-                                    scope.launch { snackbar.showSnackbar(msg) }
-                                }
-                            }
-                        },
-                        colors = SwitchDefaults.colors(
-                            checkedTrackColor = PurpleMain500,
-                            checkedThumbColor = Color.White,
-                            uncheckedTrackColor = Grey50,
-                            uncheckedThumbColor = Grey500
+                // 전체 알림 섹션
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp, horizontal = 32.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = "전체 알림",
+                            style = AppTextStyles.b1_semibold_18,
+                            color = MaterialTheme.colorScheme.onSurface
                         )
-                    )
+                        Spacer(Modifier.width(6.dp))
+                        Text(
+                            text = if (ui.pushEnabled) "허용" else "미허용",
+                            style = AppTextStyles.b1_semibold_18,
+                            color = if (ui.pushEnabled) PurpleMain500 else GreyMain300
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+
+                        Switch(
+                            checked = ui.pushEnabled,
+                            onCheckedChange = { checked ->
+                                scope.launch {
+                                    viewModel.togglePush(checked) { msg ->
+                                        scope.launch { snackbar.showSnackbar(msg) }
+                                    }
+                                }
+                            },
+                            colors = SwitchDefaults.colors(
+                                checkedTrackColor = PurpleMain500,
+                                checkedThumbColor = Color.White,
+                                uncheckedTrackColor = Grey50,
+                                uncheckedThumbColor = Grey500
+                            )
+                        )
+                    }
                 }
-            }
 
-            Spacer(Modifier.height(16.dp))
-            Divider(
-                modifier = Modifier.fillMaxWidth(),
-                color = Grey30,
-                thickness = 5.dp
-            )
-            Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(16.dp))
+                Divider(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = Grey30,
+                    thickness = 5.dp
+                )
+                Spacer(Modifier.height(16.dp))
 
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp, horizontal = 32.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(Modifier.weight(1f)) {
-                    Text("미시청 카드 리마인드 알림", style = AppTextStyles.b1_semibold_18)
-                    Spacer(Modifier.height(6.dp))
-                    Text("잊혀진 카드에 대한 리마인드를 제공합니다.", style = AppTextStyles.b3_regular_14, color = Grey500)
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp, horizontal = 32.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(Modifier.weight(1f)) {
+                        Text("미시청 카드 리마인드 알림", style = AppTextStyles.b1_semibold_18)
+                        Spacer(Modifier.height(6.dp))
+                        Text("잊혀진 카드에 대한 리마인드를 제공합니다.", style = AppTextStyles.b3_regular_14, color = Grey500)
 
 //                    // 채널 상태 + 설정 이동
 //                    Spacer(Modifier.height(8.dp))
@@ -174,27 +202,36 @@ fun NotificationSetScreen(
 //                            contentPadding = PaddingValues(0.dp)
 //                        ) { Text("채널 설정", style = AppTextStyles.b2_semibold_16, color = PurpleMain500) }
 //                    }
-                }
+                    }
 
-                // ④ 스위치 활성 조건 = 서버 on && 시스템 on && 채널 on
-                val enabled = ui.pushEnabled && notificationsEnabled && reminderChannelOn
-                Switch(
-                    checked = ui.remindEnabled,
-                    enabled = enabled,
-                    onCheckedChange = { checked ->
-                        scope.launch {
-                            viewModel.toggleRemind(checked) { msg ->  scope.launch { snackbar.showSnackbar(msg) } }
-                        }
-                    },
-                    colors = SwitchDefaults.colors(
-                        checkedTrackColor = PurpleMain500,
-                        checkedThumbColor = Color.White,
-                        uncheckedTrackColor = Grey50,
-                        uncheckedThumbColor = Grey500
+                    // ④ 스위치 활성 조건 = 서버 on && 시스템 on && 채널 on
+                    val enabled = ui.pushEnabled && notificationsEnabled && reminderChannelOn
+                    Switch(
+                        checked = ui.remindEnabled,
+                        enabled = enabled,
+                        onCheckedChange = { checked ->
+                            scope.launch {
+                                viewModel.toggleRemind(checked) { msg ->  scope.launch { snackbar.showSnackbar(msg) } }
+                            }
+                        },
+                        colors = SwitchDefaults.colors(
+                            checkedTrackColor = PurpleMain500,
+                            checkedThumbColor = Color.White,
+                            uncheckedTrackColor = Grey50,
+                            uncheckedThumbColor = Grey500
+                        )
                     )
-                )
+                }
             }
+
+            AppToastHost(
+                hostState = toastHost,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = rememberImeOrNavBottomPadding(extra = 24.dp))
+            )
         }
+
     }
 }
 
@@ -268,6 +305,15 @@ private fun NotiTopBar(onBack: () -> Unit) {
             modifier = Modifier.align(Alignment.Center)
         )
     }
+}
+
+@Composable
+private fun rememberImeOrNavBottomPadding(extra: Dp = 0.dp): Dp {
+    val density = LocalDensity.current
+    val imeBottom = WindowInsets.ime.getBottom(density)
+    val navBottom = WindowInsets.navigationBars.getBottom(density)
+    val bottomPx = max(imeBottom, navBottom)
+    return with(density) { bottomPx.toDp() } + extra
 }
 
 // 프리뷰

--- a/app/src/main/java/com/example/nubo/ui/screen/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/nubo/ui/screen/profile/ProfileViewModel.kt
@@ -7,11 +7,24 @@ import com.example.nubo.data.model.ProfileResponse
 import com.example.nubo.data.network.ProfileService
 import com.example.nubo.data.repository.ProfileRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import javax.inject.Inject
+
+// 1) 이벤트 타입 정의: ViewModel은 Compose 타입에 의존하지 않도록 String + Kind만 전달
+sealed interface ProfileEvent {
+    data class ShowToast(
+        val message: String,
+        val kind: ToastKind = ToastKind.NORMAL,
+        val durationMillis: Int = 1600
+    ) : ProfileEvent
+}
+
+enum class ToastKind { NORMAL, POSITIVE, NEGATIVE }
 
 data class ProfileUiState(
     val isLoading: Boolean = false,
@@ -29,6 +42,9 @@ class ProfileViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(ProfileUiState(isLoading = true))
     val uiState: StateFlow<ProfileUiState> = _uiState
+
+    private val _events = MutableSharedFlow<ProfileEvent>()
+    val events: SharedFlow<ProfileEvent> = _events
 
     init {
         // 로컬 캐시에서 마지막 알림 상태 복원
@@ -109,10 +125,27 @@ class ProfileViewModel @Inject constructor(
                 remindEnabled = if (!checked) false else null
             )
             profileRepository.updateNotification(req)
-                .onSuccess { profileRepository.saveNotificationPrefs(checked, nextRemind) }
+                .onSuccess {
+
+                    profileRepository.saveNotificationPrefs(checked, nextRemind)
+                    _events.emit(
+                        ProfileEvent.ShowToast(
+                            message = if (checked) "전체 알림 켰어요." else "전체 알림 껐어요",
+                            kind = ToastKind.NORMAL
+                        )
+                    )
+                }
                 .onFailure {
                     _uiState.value = prev
-                    onError(it.message ?: "알림 설정 저장에 실패했습니다")
+                    val msg = it.message ?: "전체 알림 설정 저장에 실패했습니다"
+
+                    _events.emit(
+                        ProfileEvent.ShowToast(
+                            message = msg,
+                            kind = ToastKind.NEGATIVE,
+                            durationMillis = 2000
+                        )
+                    )
                 }
         }
     }
@@ -129,10 +162,24 @@ class ProfileViewModel @Inject constructor(
             profileRepository.updateNotification(req)
                 .onSuccess {
                     profileRepository.saveNotificationPrefs(_uiState.value.pushEnabled, checked)
+                    _events.emit(
+                        ProfileEvent.ShowToast(
+                            message = if (checked) "리마인드 알림을 켰어요." else "리마인드 알림을 껐어요.",
+                            kind = ToastKind.NORMAL
+                        )
+                    )
                 }
                 .onFailure {
                     _uiState.value = prev
-                    onError(it.message ?: "리마인드 설정 저장에 실패했습니다")
+                    val msg = it.message ?: "리마인드 설정 저장에 실패했습니다"
+
+                    _events.emit(
+                        ProfileEvent.ShowToast(
+                            message = msg,
+                            kind = ToastKind.NEGATIVE,
+                            durationMillis = 2000
+                        )
+                    )
                 }
         }
     }


### PR DESCRIPTION
### 1. 커스텀 토스트
- 토스트 표시 시 시스템 인셋(IME·NavigationBar) 반영 오류 수정
- Popup 제거 조건 개선으로 터치 차단 버그 해결

### 2. 알림 설정
- 기기 연동 상태 기반으로 알림 토글 제어 추가
- 알림 토글 시 커스텀 토스트 표시 로직 연동 (ProfileViewModel → NotificationSetScreen 이벤트 처리)

### 3. FCM
- 등록된 FCM 토큰 중복 삭제 및 재생성 방지 로직 추가
- SharedPreferences 기반 로컬 캐시 비교 및 최신 상태 유지